### PR TITLE
Adding Minar Time Mask setting and correcting HSI value

### DIFF
--- a/target.json
+++ b/target.json
@@ -49,7 +49,8 @@
   "config": {
     "minar": {
       "initial_event_pool_size": 20,
-      "additional_event_pools_size": 50
+      "additional_event_pools_size": 50,
+      "platform_time_mask": "0xFFFFu"
     },
     "mbed-os": {},
     "cmsis": {
@@ -63,7 +64,7 @@
     },
     "hardware": {
       "externalClock": "8000000",
-      "internalClock": "16000000",
+      "internalClock": "8000000",
       "pins": {
         "LED1": "PA_5",
         "LED2": "NC",


### PR DESCRIPTION
- The Internal Clock value (that indicates the internal Oscillator Frequency) was set wrongly to 16000000, changed to 8000000.
- Adding correct time mask for f091 devices.
